### PR TITLE
NGWMN-1976 Add Django migrations to the Dockerfile startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,20 @@ FROM usgswma/python:3.8
 
 ENV PYTHONUNBUFFERED 1
 
-WORKDIR $HOME/application
-
 COPY . $HOME/application
 
-RUN pip install --no-cache-dir -r requirements.txt
+WORKDIR $HOME/application/wellregistry
+
+RUN pip install --no-cache-dir -r ../requirements.txt
 
 USER $USER
 
 EXPOSE 8000
 
-CMD ["gunicorn", "--chdir", "wellregistry", "--config", "wellregistry/gunicorn.conf.py", "wellregistry.wsgi"]
+# Run the Django migrations to ensure the DB tier is up to date.
+# Django, like liquibase, executes each entry once.
+# The order below is important initial database configuration.
+CMD python -m manage migrate --database=postgres postgres
+ && python -m manage migrate registry 0000
+ && python -m manage migrate registry
+ && gunicorn --config wellregistry/gunicorn.conf.py wellregistry.wsgi


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Description
-----------
We need the database updates to be applied to each tier. It seems to make sense to apply them at deployment. It is a small impact on the startup with a large impact on reliability. Nobody has to remember to run a special DB job when deploying to the tiers. Django does not run entries that have been run before.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
