### PR TITLE
NGWMN-1976 fix docker CMD missing line continuation char

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ EXPOSE 8000
 # Run the Django migrations to ensure the DB tier is up to date.
 # Django, like liquibase, executes each entry once.
 # The order below is important initial database configuration.
-CMD python -m manage migrate --database=postgres postgres
- && python -m manage migrate registry 0000
- && python -m manage migrate registry
+CMD python -m manage migrate --database=postgres postgres \
+ && python -m manage migrate registry 0000 \
+ && python -m manage migrate registry \
  && gunicorn --config wellregistry/gunicorn.conf.py wellregistry.wsgi


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
see PR title

Description
-----------
There was a bug in the CMD line in the Dockerfile. It was missing the line continuation char '\' for the multiple line command. Alternatively, in the future, we would create a startup bash script.

On other note, the last migration command specifies the 'registry' and I am reasonably sure that we could leave that off to apply all migrations afterwards.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
