### PR TITLE
NGWMN-1976 update Dockerfile for psycopg2 module build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY . $HOME/application
 
 WORKDIR $HOME/application/wellregistry
 
+RUN apt-get update
+RUN apt-get install build-essential libpq-dev python3-dev -y
+
 RUN pip install --no-cache-dir -r ../requirements.txt
 RUN pip install --no-cache-dir -r ../requirements-prod.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ COPY . $HOME/application
 
 WORKDIR $HOME/application/wellregistry
 
-RUN apt-get update
-RUN apt-get install build-essential libpq-dev python3-dev -y
-
-RUN pip install --no-cache-dir -r ../requirements.txt
-RUN pip install --no-cache-dir -r ../requirements-prod.txt
+RUN apt-get update \
+ && apt-get install gcc libpq-dev python3-dev -y \
+ && pip install --no-cache-dir -r ../requirements-prod.txt \
+ && apt-get autoremove --purge -y build-essential libpq-dev python3-dev \
+ && rm -rf /var/lib/apt/lists/* \
+ && pip install --no-cache-dir -r ../requirements.txt
 
 USER $USER
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $HOME/application/wellregistry
 RUN apt-get update \
  && apt-get install gcc libpq-dev python3-dev -y \
  && pip install --no-cache-dir -r ../requirements-prod.txt \
- && apt-get autoremove --purge -y build-essential libpq-dev python3-dev \
+ && apt-get autoremove --purge -y gcc libpq-dev python3-dev \
  && rm -rf /var/lib/apt/lists/* \
  && pip install --no-cache-dir -r ../requirements.txt
 


### PR DESCRIPTION
Title
-----------
psycopg2 build requirements in the Dockerfile

Description
-----------
The psycopg2 module used to be a self contained wheel. That has been moved to psycopg2-binary.
The wheel release has an incompatibility with a library (SSL) that has a global variable that changes when https requests are made while the database connections are also in use. This causes a segmentation fault race condition. The new release pattern require a compile on each distro.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
