### PR TITLE
changed headers in monitoring location view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -   Fixed the Delete button styling so button is full height.
 ### Changed
-   Changed headers in Well Registry SiteID, Agency, SiteNo, Display Site, In WL Subnetwork?, In QW Subnetwork?, State, Principal Aquifer, Site Name
+   Updated information shown on the monitoring locations list
 ## [0.1.0](https://github.com/ACWI-SOGW/well_registry_management/tree/wellregistry-0.1.0) - 2020-11-05
 ### Added
 -   Added Django Admin which allows adding/changing of monitoring locations. This part of the application requires login either through BisonConnect or through a login provided by the well registry administrators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added Filtering for site_no, state, county, dislplay_flag, and national aquifer 
 ### Fixed
 -   Fixed the Delete button styling so button is full height.
+### Changed
+   Changed headers in Well Registry SiteID, Agency, SiteNo, Display Site, In WL Subnetwork?, In QW Subnetwork?, State, Principal Aquifer, Site Name
 ## [0.1.0](https://github.com/ACWI-SOGW/well_registry_management/tree/wellregistry-0.1.0) - 2020-11-05
 ### Added
 -   Added Django Admin which allows adding/changing of monitoring locations. This part of the application requires login either through BisonConnect or through a login provided by the well registry administrators.

--- a/wellregistry/registry/admin/monitoring_location.py
+++ b/wellregistry/registry/admin/monitoring_location.py
@@ -431,7 +431,7 @@ class MonitoringLocationAdmin(ModelAdmin):
     """
     form = MonitoringLocationAdminForm
     list_display = ('site_id', 'agency', 'site_no', 'display_flag', 'wl_sn_flag', 'qw_sn_flag',
-                    'insert_date', 'update_date')
+                    'state', 'nat_aqfr', 'site_name')
     list_filter = (
         ('agency', SelectListFilter),
         ('state', SelectListFilter),


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ x ] Make sure all tests run
- [ x ] Update the changelog appropriately

Title
-----------
The default information shown in the site table in the well registry ( https://labs-dev.wma.chs.usgs.gov/registry/admin/registry/monitoringlocation/) should contain:

Description
-----------

SiteID
Agency
SiteNo
Display Site
In WL Subnetwork?
In QW Subnetwork?
State
Principal Aquifer
Site Name
 

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
